### PR TITLE
Fix change TLS options before AUTH

### DIFF
--- a/upload/src/addons/SV/RedisCache/Traits/Cm_Cache_Backend_Redis.php
+++ b/upload/src/addons/SV/RedisCache/Traits/Cm_Cache_Backend_Redis.php
@@ -435,14 +435,14 @@ trait Cm_Cache_Backend_Redis
             $client->setReadTimeout($clientOptions->readTimeout);
         }
 
-        if ($clientOptions->password)
-        {
-            $client->auth($clientOptions->password, $clientOptions->username ?? null) or $this->throwException('Unable to authenticate with the redis server.');
-        }
-
         if ($clientOptions->tlsOptions)
         {
             $client->setTlsOptions($clientOptions->tlsOptions);
+        }
+
+        if ($clientOptions->password)
+        {
+            $client->auth($clientOptions->password, $clientOptions->username ?? null) or $this->throwException('Unable to authenticate with the redis server.');
         }
 
         // Always select database when persistent is used in case connection is re-used by other clients


### PR DESCRIPTION
Fixes issue:
```
EXCEPTION: Cannot change TLS options after a connection has already been established.
File: src/addons/SV/RedisCache/Credis/Client.php:494
#0 src/addons/SV/RedisCache/Traits/Cm_Cache_Backend_Redis.php(445): Credis_Client->setTlsOptions(Array)
#1 src/addons/SV/RedisCache/Traits/Cm_Cache_Backend_Redis.php(301): SV\RedisCache\SymfonyCache\Redis->_applyClientOptions(Object(Credis_Client))
#2 src/addons/SV/RedisCache/SymfonyCache/Redis.php(59): SV\RedisCache\SymfonyCache\Redis->init(Array)
#3 src/XF/CacheFactory.php(97): SV\RedisCache\SymfonyCache\Redis->__construct(Array)
#4 src/XF/CacheFactory.php(49): XF\CacheFactory->instantiate('SV\\RedisCache\\R...', Array)
#5 src/XF/App.php(832): XF\CacheFactory->create('SV\\RedisCache\\R...', Array, false)
#6 src/XF/Container.php(233): XF\App->XF\{closure}('', Array, Object(XF\Container))
#7 src/XF/App.php(3004): XF\Container->create('cache.symfony', '')
#8 src/XF/App.php(877): XF\App->cache('registry', true, false)
#9 src/XF/Container.php(33): XF\App->XF\{closure}(Object(XF\Container))
#10 src/XF/App.php(2176): XF\Container->offsetGet('registry')
#11 src/XF/Container.php(33): XF\App->XF\{closure}(Object(XF\Container))
#12 src/XF/App.php(1821): XF\Container->offsetGet('extension.liste...')
#13 src/XF/Container.php(33): XF\App->XF\{closure}(Object(XF\Container))
#14 src/XF/App.php(3352): XF\Container->offsetGet('extension')
#15 src/XF/App.php(3383): XF\App->extension()
#16 src/XF/App.php(1629): XF\App->extendClass('XF\\AddOn\\Manage...')
#17 src/XF/Container.php(33): XF\App->XF\{closure}(Object(XF\Container))
#18 src/XF/App.php(2796): XF\Container->offsetGet('addon.manager')
#19 src/XF/App.php(2274): XF\App->setupAddOnComposerAutoload()
#20 src/XF/Pub/App.php(116): XF\App->setup(Array)
#21 src/XF.php(779): XF\Pub\App->setup(Array)
#22 {main}
```

when using config options like
```
   'tlsOptions' => [
        'verify_peer' => false,
        'verify_peer_name' => false,
    ],
```