### PR TITLE
Fix compress threshold calculation to ensure it is always at least 1

### DIFF
--- a/upload/src/addons/SV/RedisCache/Traits/Cm_Cache_Backend_Redis.php
+++ b/upload/src/addons/SV/RedisCache/Traits/Cm_Cache_Backend_Redis.php
@@ -363,7 +363,7 @@ trait Cm_Cache_Backend_Redis
 
         $this->_compressData = (int)($options['compress_data'] ?? $this->_compressData);
         $this->_lifetimelimit = (int)min($options['lifetimelimit'] ?? $this->_lifetimelimit , Globals::MAX_LIFETIME);
-        $this->_compressThreshold = (int)min(1, (int)($options['compress_threshold'] ?? $this->_compressThreshold));
+        $this->_compressThreshold = (int)max(1, (int)($options['compress_threshold'] ?? $this->_compressThreshold));
 
         $this->_compressionLib = (string)($options['compression_lib'] ?? '');
         if ($this->_compressionLib === '')


### PR DESCRIPTION
with `min(1, ` it's always 1 (or 0 if the compress_threshold is 0), essentially everything was compressed?